### PR TITLE
Caddy 1.0.4 update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.7
+FROM alpine:3.11
 
 LABEL maintainer="Nikita Sobolev <sobolevn@wemake.services>"
 
-ARG VERSION="0.10.11"
+ARG VERSION="1.0.4"
 
 RUN apk update && apk upgrade \
   && apk add --no-cache openssh-client git \
@@ -22,4 +22,4 @@ VOLUME /root/.caddy
 COPY Caddyfile /etc/Caddyfile
 
 ENTRYPOINT ["/usr/bin/caddy"]
-CMD ["--conf", "/etc/Caddyfile", "--log", "stdout"]
+CMD ["--conf", "/etc/Caddyfile", "--log", "stdout", "--agree", "--disabled-metrics"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ VOLUME /root/.caddy
 COPY Caddyfile /etc/Caddyfile
 
 ENTRYPOINT ["/usr/bin/caddy"]
-CMD ["--conf", "/etc/Caddyfile", "--log", "stdout", "--agree", "--disabled-metrics"]
+CMD ["--conf", "/etc/Caddyfile", "--log", "stdout", "--agree"]


### PR DESCRIPTION
This PR is related to this issue of [deprecated challenges used in v0.10.X of Caddy](https://github.com/wemake-services/wemake-django-template/issues/1049).

I understand that alternatives are being considered, however, we have decided to continue with Caddy for the time being. Thus, a version bump and adding the auto-agree CLI argument seems to have done the trick.

I think this addresses #3 and #6